### PR TITLE
Support function declarations and invocations

### DIFF
--- a/src/verifier/mod.rs
+++ b/src/verifier/mod.rs
@@ -1,25 +1,33 @@
 mod vcg;
 mod translator;
 
-use std::collections::HashMap;
+use std::collections::{HashMap};
 use z3::ast::{Dynamic};
+use z3::{FuncDecl};
 pub use vcg::*;
-//
 
-#[derive(Clone)]
+
 pub struct Environment<'a> {
     /// Map local variables.
     bindings: HashMap<String,Dynamic<'a>>,
+    /// Bind function names to declarations.
+    fn_bindings: HashMap<String, FuncDecl<'a>>,
 }
 
 impl<'a> Environment<'a> {
     pub fn new() -> Self {
-        Self{bindings: HashMap::new() }
+        Self{bindings: HashMap::new(), fn_bindings: HashMap::new() }
     }
     pub fn alloc(&mut self, name: &str, kind: Dynamic<'a>) {
         self.bindings.insert(name.to_string(), kind);
     }
     pub fn lookup(&self, name: &str) -> &Dynamic<'a> {
         self.bindings.get(name).unwrap()
+    }
+    pub fn declare_fn(&mut self, decl: FuncDecl<'a>) {
+        self.fn_bindings.insert(decl.name(), decl);
+    }
+    pub fn lookup_fn(&self, name: &str) -> &FuncDecl<'a> {
+        self.fn_bindings.get(name).unwrap()
     }
 }

--- a/src/verifier/translator.rs
+++ b/src/verifier/translator.rs
@@ -1,8 +1,10 @@
 use z3::*;
-use z3::ast::{Ast,Bool,Int};
+use z3::ast::{Ast,Bool,Dynamic,Int};
 use z3::{Context};
 
 use crate::{BinOp,Environment,SyntacticHeap,Term};
+
+use BinOp::*;
 
 /// Responsible for translating terms in the high-level Abstract
 /// Syntax Tree.
@@ -18,23 +20,27 @@ impl<'a,'b> Translator<'a,'b> {
 	Self{heap,context,env}
     }
 
-    // ===============================================================
-    // Integer Expressions
-    // ===============================================================
+    // =========================================================================
+    // Public Interface
+    // =========================================================================
 
-    pub fn translate_int(&mut self, index: usize) -> Int<'a> {
+    /// Translate the term at a given `index` position within the heap
+    /// into an AST node.
+    pub fn translate(&mut self, index: usize) -> Dynamic<'a> {
         // Must be valid term
         assert!(index < self.heap.len());
         //
         let term = self.heap.get(index);
         match term {
-            Term::Block(stmts) => self.translate_int_block(stmts),
+            Term::Block(stmts) => self.translate_block(stmts),
             // Expressions
-            Term::Binary(bop,lhs,rhs) => self.translate_int_binary(*bop,*lhs,*rhs),
-            Term::Braced(lhs) => self.translate_int(*lhs),
-            Term::IfElse{cond,tt,ff} => self.translate_int_ifelse(*cond,*tt,*ff),
-            Term::VarAccess(s) =>  self.translate_int_var(s),
+            Term::Binary(bop,lhs,rhs) => self.translate_binary(*bop,*lhs,*rhs),
+            Term::Braced(lhs) => self.translate(*lhs),
+            Term::IfElse{cond,tt,ff} => self.translate_ifelse(*cond,*tt,*ff),
+            Term::StaticInvoke(n,args) => self.translate_static_invoke(n,args),
+            Term::VarAccess(s) =>  self.translate_var(s),
             // Literals
+            Term::BoolLiteral(v) => self.translate_bool_literal(*v),
             Term::IntLiteral(v) => self.translate_int_literal(*v),
 	    _ => {
 		panic!("unexpected term encountered {term:?}");
@@ -42,17 +48,68 @@ impl<'a,'b> Translator<'a,'b> {
         }
     }
 
-    fn translate_int_block(&mut self, indices: &[usize]) -> Int<'a> {
-        assert_eq!(indices.len(),1,"multi-statement blocks not yet supported");
-        self.translate_int(indices[0])
+    /// Translate the term at a given `index` position within the heap
+    /// into a _boolean_ AST node.
+    pub fn translate_bool(&mut self, index: usize) -> Bool<'a> {
+        self.translate(index).as_bool().unwrap()
     }
 
-    fn translate_int_binary(&mut self, bop: BinOp, lhs: usize, rhs: usize) -> Int<'a> {
+    /// Translate the term at a given `index` position within the heap
+    /// into a _integer_ AST node.
+    pub fn translate_int(&mut self, index: usize) -> Int<'a> {
+        self.translate(index).as_int().unwrap()
+    }
+
+    /// Translate the term at a given `index` position within the heap
+    /// into a _sort_.  Hence, this assumes the term at `index`
+    /// corresponds to a type.
+    pub fn translate_type(&mut self, index: usize) -> Sort<'a> {
+        // Must be valid term
+        assert!(index < self.heap.len());
+        //
+        let term = self.heap.get(index);
+        // Types
+        match term {
+            Term::ArrayType(usize) => todo!(),
+            Term::BoolType => Sort::bool(self.context),
+            Term::IntType(_) => Sort::int(self.context),
+            Term::TupleType(_) => todo!(),
+            _ => { unreachable!() }
+        }
+    }
+
+    // =========================================================================
+    // Private Translation Helpers
+    // =========================================================================
+
+    fn translate_block(&mut self, indices: &[usize]) -> Dynamic<'a> {
+        assert_eq!(indices.len(),1,"multi-statement blocks not yet supported");
+        self.translate(indices[0])
+    }
+
+    /// Translate an arbitrary binary expression.  This is done by
+    /// considering the main categories separately.
+    fn translate_binary(&mut self, bop: BinOp, lhs: usize, rhs: usize) -> Dynamic<'a> {
+        match bop {
+            // Arithmetic
+            Add|Subtract|Multiply|Divide|Remainder => self.translate_arithmetical(bop,lhs,rhs),
+            // Comparators
+            LessThan|LessThanOrEquals|GreaterThan|GreaterThanOrEquals => self.translate_relational(bop,lhs,rhs),
+            // Equality
+            Equals|NotEquals => self.translate_equational(bop,lhs,rhs),
+            // Logic
+            LogicalAnd|LogicalOr|LogicalImplies => self.translate_logical(bop,lhs,rhs),
+            //
+            _ => { unreachable!() }
+        }
+    }
+
+    fn translate_arithmetical(&mut self, bop: BinOp, lhs: usize, rhs: usize) -> Dynamic<'a> {
         // Translate lhs and rhs
         let l = self.translate_int(lhs);
         let r = self.translate_int(rhs);
 
-        match bop {
+        let v = match bop {
             // Arithmetic
             BinOp::Add => { Int::add(self.context,&[&l,&r]) }
             BinOp::Subtract => { Int::sub(self.context,&[&l,&r]) }
@@ -60,89 +117,94 @@ impl<'a,'b> Translator<'a,'b> {
             BinOp::Divide => { l.div(&r) }
             BinOp::Remainder => { l.rem(&r) }
             _ => { unreachable!() }
-        }
+        };
+        // Convert to Dynamic
+        Dynamic::from_ast(&v)
     }
 
-    fn translate_int_ifelse(&mut self, cond: usize, lhs: usize, rhs: usize) -> Int<'a> {
-        let c = self.translate_bool(cond);
-        let l = self.translate_int(lhs); // broken (might not be int)
-        let r = self.translate_int(rhs); // broken (might not be int)
-        c.ite(&l,&r)
-    }
-
-    fn translate_int_var(&mut self, var: &str) -> Int<'a> {
-        self.env.lookup(var).as_int().unwrap()
-    }
-
-    fn translate_int_literal(&mut self, val: usize) -> Int<'a> {
-        // TODO: should fix this cast :)
-        Int::from_u64(self.context,val as u64)
-    }
-
-    // ===============================================================
-    // Logical Expressions
-    // ===============================================================
-
-    pub fn translate_bool(&mut self, index: usize) -> Bool<'a> {
-        // Must be valid term
-        assert!(index < self.heap.len());
-        //
-        let term = self.heap.get(index);
-        match term {
-            // Expressions
-            Term::Binary(bop,lhs,rhs) => self.translate_bool_binary(*bop,*lhs,*rhs),
-            Term::Braced(lhs) => self.translate_bool(*lhs),
-            Term::VarAccess(s) =>  self.translate_bool_var(s),
-            // Literals
-            Term::BoolLiteral(v) => self.translate_bool_literal(*v),
-	    _ => { unreachable!(); }
-        }
-    }
-
-    fn translate_bool_binary(&mut self, bop: BinOp, lhs: usize, rhs: usize) -> Bool<'a> {
-        // Split based on operand type
-        match bop {
-            BinOp::LogicalAnd|BinOp::LogicalImplies|BinOp::LogicalOr =>
-                self.translate_bool_logical(bop,lhs,rhs),
-            _ => self.translate_bool_relational(bop,lhs,rhs)
-        }
-    }
-
-    fn translate_bool_logical(&mut self, bop: BinOp, lhs: usize, rhs: usize) -> Bool<'a> {
+    fn translate_equational(&mut self, bop: BinOp, lhs: usize, rhs: usize) -> Dynamic<'a> {
         // Translate lhs and rhs
-        let l = self.translate_bool(lhs);
-        let r = self.translate_bool(rhs);
+        let l = self.translate(lhs);
+        let r = self.translate(rhs);
         //
-        match bop {
-            BinOp::LogicalAnd => { Bool::and(self.context,&[&l,&r]) }
-            BinOp::LogicalOr => { Bool::or(self.context,&[&l,&r]) }
-            BinOp::LogicalImplies => { l.implies(&r) }
+        let b = match bop {
+            BinOp::Equals => { l._eq(&r) }
+            BinOp::NotEquals => { Ast::distinct(self.context,&[&l,&r]) }
+            //
             _ => { unreachable!() }
-        }
+        };
+        // Convert to dynamic
+        Dynamic::from_ast(&b)
     }
 
-    fn translate_bool_relational(&mut self, bop: BinOp, lhs: usize, rhs: usize) -> Bool<'a> {
+    fn translate_relational(&mut self, bop: BinOp, lhs: usize, rhs: usize) -> Dynamic<'a> {
         // Translate lhs and rhs
         let l = self.translate_int(lhs);
         let r = self.translate_int(rhs);
         //
-        match bop {
-            BinOp::Equals => { l._eq(&r) }
-            BinOp::NotEquals => { Ast::distinct(self.context,&[&l,&r]) }
+        let b = match bop {
             BinOp::LessThan => { l.lt(&r) }
             BinOp::LessThanOrEquals => { l.le(&r) }
             BinOp::GreaterThan => { l.gt(&r) }
             BinOp::GreaterThanOrEquals => { l.ge(&r) }
             //
             _ => { unreachable!() }
+        };
+        // Convert to dynamic
+        Dynamic::from_ast(&b)
+    }
+
+    fn translate_logical(&mut self, bop: BinOp, lhs: usize, rhs: usize) -> Dynamic<'a> {
+        // Translate lhs and rhs
+        let l = self.translate_bool(lhs);
+        let r = self.translate_bool(rhs);
+        //
+        let b = match bop {
+            BinOp::LogicalAnd => { Bool::and(self.context,&[&l,&r]) }
+            BinOp::LogicalOr => { Bool::or(self.context,&[&l,&r]) }
+            BinOp::LogicalImplies => { l.implies(&r) }
+            _ => { unreachable!() }
+        };
+        // Convert to dynamic
+        Dynamic::from_ast(&b)
+    }
+
+    fn translate_ifelse(&mut self, cond: usize, lhs: usize, rhs: usize) -> Dynamic<'a> {
+        let c = self.translate_bool(cond);
+        let l = self.translate(lhs);
+        let r = self.translate(rhs);
+        c.ite(&l,&r)
+    }
+
+    fn translate_static_invoke(&mut self, name: &str, args: &[usize]) -> Dynamic<'a> {
+        let fdecl = self.env.lookup_fn(name);
+        let mut dumb = Vec::new();
+        let mut vargs : Vec<&dyn Ast<'_>> = Vec::new();
+        // Yes, this is a tad frustrating.
+        for i in 0..args.len() {
+            // FIXME: following might not be int of course :)
+            dumb.push(self.translate(args[i]));
         }
+        for i in 0..args.len() {
+            vargs.push(&dumb[i]);
+        }
+        fdecl.apply(&vargs)
     }
 
-    fn translate_bool_var(&mut self, var: &str) -> Bool<'a> {
-        self.env.lookup(var).as_bool().unwrap()
+    fn translate_var(&mut self, var: &str) -> Dynamic<'a> {
+        self.env.lookup(var).clone()
     }
 
-    fn translate_bool_literal(&mut self, val: bool) -> Bool<'a> {
-        Bool::from_bool(self.context,val)
+    fn translate_bool_literal(&mut self, val: bool) -> Dynamic<'a> {
+        let ast = Bool::from_bool(self.context,val);
+        // Convert
+        Dynamic::from_ast(&ast)
+    }
+
+    fn translate_int_literal(&mut self, val: usize) -> Dynamic<'a> {
+        // TODO: should fix this cast :)
+        let ast = Int::from_u64(self.context,val as u64);
+        // Convert to dynamic
+        Dynamic::from_ast(&ast)
     }
 }


### PR DESCRIPTION
This translates function declarations into uninterpreted declarations, and compiles invocations accordingly.  To make this work, declarations must be stored in the environment so they can be recalled at the point of invocation.

To correctly handle the translation of arguments, the two translation methods (i.e. for `int` and for `bool`) have been combined into a single `translate()` method which returns `Dynamic`.  That seems to be working quite well.

Finally, note at this stage, checking preconditions at the point of invocation is not yet supported.  Likewise, incorporating postconditions is not supported either.