### PR TITLE
Support `ite` expressions

### DIFF
--- a/src/circuit/smtlib/ast.rs
+++ b/src/circuit/smtlib/ast.rs
@@ -1,6 +1,6 @@
 /// Set of built-in operators
 #[derive(Clone,Copy,Debug,PartialEq)]
-pub enum NaryOp {
+pub enum Op {
     Eq,
     Neq,
     // Arithmetical
@@ -17,39 +17,40 @@ pub enum NaryOp {
     // Logical
     Or,
     And,
-    Implies
+    Implies,
+    Not,
+    // Other
+    IfThenElse
 }
 
-impl NaryOp {
-    pub fn as_str(&self) -> &str {
+impl Op {
+    /// Determine how many arguments are expected
+    pub fn arity(&self) -> usize {
         match self {
-            NaryOp::Eq => "=",
-            NaryOp::Neq => "!=",
-            NaryOp::Add => "+",
-            NaryOp::Sub => "-",
-            NaryOp::Mul => "*",
-            NaryOp::Div => "div",
-            NaryOp::Mod => "mod",
-            NaryOp::Gt => ">",
-            NaryOp::GtEq => ">=",
-            NaryOp::Lt => "<",
-            NaryOp::LtEq => "<=",
-            NaryOp::Or => "or",
-            NaryOp::And => "and",
-            NaryOp::Implies => "=>"
+            Op::IfThenElse => 3,
+            Op::Not => 1,
+            _ => usize::MAX
         }
     }
-}
-
-#[derive(Clone,Copy,Debug,PartialEq)]
-pub enum UnaryOp {
-    Not
-}
-
-impl UnaryOp {
+    /// Get the string representation of this operator.
     pub fn as_str(&self) -> &str {
         match self {
-            UnaryOp::Not => "not",
+            Op::Eq => "=",
+            Op::Neq => "!=",
+            Op::Add => "+",
+            Op::Sub => "-",
+            Op::Mul => "*",
+            Op::Div => "div",
+            Op::Mod => "mod",
+            Op::Gt => ">",
+            Op::GtEq => ">=",
+            Op::Lt => "<",
+            Op::LtEq => "<=",
+            Op::Or => "or",
+            Op::And => "and",
+            Op::Implies => "=>",
+            Op::Not => "not",
+            Op::IfThenElse => "ite"
         }
     }
 }
@@ -61,9 +62,7 @@ pub enum Expr {
     /// Boolean Literal
     Boolean(bool),
     /// Nary Expression
-    Nary(NaryOp,Vec<Expr>),
-    /// Unary Expression
-    Unary(UnaryOp,Box<Expr>),
+    Operator(Op,Vec<Expr>),
     /// Variable Access
     VarAccess(String)
 }

--- a/src/circuit/smtlib/circuit.rs
+++ b/src/circuit/smtlib/circuit.rs
@@ -3,8 +3,7 @@ use super::SmtLibWriter;
 use super::ast::*;
 use super::solver::SmtOutcome;
 
-use super::ast::NaryOp::*;
-use super::ast::UnaryOp::*;
+use super::ast::Op::*;
 
 // =============================================================================
 // SmtLib Circuit
@@ -90,11 +89,11 @@ impl<'a> circuit::Any for Expr {
     type Bool = Expr;
 
     fn eq(&self, other: &Self) -> Self::Bool {
-        Expr::Nary(Eq,vec![self.clone(),other.clone()])
+        Expr::Operator(Eq,vec![self.clone(),other.clone()])
     }
 
     fn neq(&self, other: &Self) -> Self::Bool {
-        Expr::Nary(Neq,vec![self.clone(),other.clone()])
+        Expr::Operator(Neq,vec![self.clone(),other.clone()])
     }
 }
 
@@ -111,19 +110,19 @@ impl<'a> circuit::Bool for Expr {
         self.clone()
     }
     fn not(&self) -> Self {
-        Expr::Unary(Not,Box::new(self.clone()))
+        Expr::Operator(Not,vec![self.clone()])
     }
     fn and(&self, other: &Self) -> Self {
-        Expr::Nary(And,vec![self.clone(),other.clone()])
+        Expr::Operator(And,vec![self.clone(),other.clone()])
     }
     fn or(&self, other: &Self) -> Self {
-        Expr::Nary(Or,vec![self.clone(),other.clone()])
+        Expr::Operator(Or,vec![self.clone(),other.clone()])
     }
     fn implies(&self, other: &Self) -> Self {
-        Expr::Nary(Implies,vec![self.clone(),other.clone()])
+        Expr::Operator(Implies,vec![self.clone(),other.clone()])
     }
     fn ite(&self, lhs: &Self::Any, rhs: &Self::Any) -> Self::Any {
-        todo!()
+        Expr::Operator(IfThenElse,vec![self.clone(),lhs.clone(),rhs.clone()])
     }
 }
 
@@ -145,33 +144,33 @@ impl circuit::Int for Expr {
     // Comparators
     fn non_zero(&self) -> Self::Bool { todo!() }
     fn lt(&self, other: &Self) -> Self::Bool {
-        Expr::Nary(Lt,vec![self.clone(),other.clone()])
+        Expr::Operator(Lt,vec![self.clone(),other.clone()])
     }
     fn lteq(&self, other: &Self) -> Self::Bool {
-        Expr::Nary(LtEq,vec![self.clone(),other.clone()])
+        Expr::Operator(LtEq,vec![self.clone(),other.clone()])
     }
     fn gt(&self, other: &Self) -> Self::Bool {
-        Expr::Nary(Gt,vec![self.clone(),other.clone()])
+        Expr::Operator(Gt,vec![self.clone(),other.clone()])
     }
     fn gteq(&self, other: &Self) -> Self::Bool {
-        Expr::Nary(GtEq,vec![self.clone(),other.clone()])
+        Expr::Operator(GtEq,vec![self.clone(),other.clone()])
     }
-    // Arithmetic NaryOperators
-    fn neg(&self) -> Self { Expr::Nary(Sub,vec![self.clone()]) }
+    // Arithmetic OperatorOperators
+    fn neg(&self) -> Self { Expr::Operator(Sub,vec![self.clone()]) }
     fn add(&self, other: &Self) -> Self {
-        Expr::Nary(Add,vec![self.clone(),other.clone()])
+        Expr::Operator(Add,vec![self.clone(),other.clone()])
     }
     fn sub(&self, other: &Self) -> Self {
-        Expr::Nary(Sub,vec![self.clone(),other.clone()])
+        Expr::Operator(Sub,vec![self.clone(),other.clone()])
     }
     fn div(&self, other: &Self) -> Self {
-        Expr::Nary(Div,vec![self.clone(),other.clone()])
+        Expr::Operator(Div,vec![self.clone(),other.clone()])
     }
     fn mul(&self, other: &Self) -> Self {
-        Expr::Nary(Mul,vec![self.clone(),other.clone()])
+        Expr::Operator(Mul,vec![self.clone(),other.clone()])
     }
     fn rem(&self, other: &Self) -> Self {
-        Expr::Nary(Mod,vec![self.clone(),other.clone()])
+        Expr::Operator(Mod,vec![self.clone(),other.clone()])
     }
 }
 

--- a/src/circuit/smtlib/printer.rs
+++ b/src/circuit/smtlib/printer.rs
@@ -56,23 +56,16 @@ impl<T:Write> SmtLibWriter<T> {
             Expr::Integer(i) => { write!(self.out,"{i}") }
             Expr::Boolean(b) => { write!(self.out,"{b}") }
             Expr::VarAccess(n) => { write!(self.out,"{n}") }
-            Expr::Nary(op,args) => self.write_nary(op,args),
-            Expr::Unary(op,arg) => self.write_unary(op,arg)
+            Expr::Operator(op,args) => self.write_nary(op,args)
         }
     }
 
-    fn write_nary(&mut self, op: &NaryOp, args: &[Expr]) -> Result<()> {
+    fn write_nary(&mut self, op: &Op, args: &[Expr]) -> Result<()> {
         write!(self.out,"({}",op.as_str())?;
         for arg in args {
             write!(self.out," ")?;
             self.write_expr(arg)?;
         }
-        write!(self.out,")")
-    }
-
-    fn write_unary(&mut self, op: &UnaryOp, arg: &Expr) -> Result<()> {
-        write!(self.out,"({} ",op.as_str())?;
-        self.write_expr(arg)?;
         write!(self.out,")")
     }
 }


### PR DESCRIPTION
This adds support for the `IfThenElse` expression form.  It also generalises builtin operations to a single `Operator` type, rather than multiple distinct types.